### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/LLM/autogen/autogen_fastapi_ex/poetry.lock
+++ b/LLM/autogen/autogen_fastapi_ex/poetry.lock
@@ -704,15 +704,15 @@ embeddings = ["matplotlib", "numpy", "openpyxl (>=3.0.7)", "pandas (>=1.2.3)", "
 wandb = ["numpy", "openpyxl (>=3.0.7)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)", "wandb"]
 
 [[package]]
-name = "pyautogen"
+name = "ag2"
 version = "0.1.13"
 description = "Enabling Next-Gen LLM Applications via Multi-Agent Conversation Framework"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pyautogen-0.1.13-py3-none-any.whl", hash = "sha256:3a022af253bae7284b5704f2155ebe111d634e88fe005b9e19ce49eb8c4cea4f"},
-    {file = "pyautogen-0.1.13.tar.gz", hash = "sha256:ed6333338b45dcc3fa82ccec691d9229b29df0cfc019b0c53eb0c276c88e1f44"},
+    {file = "ag2-0.1.13-py3-none-any.whl", hash = "sha256:3a022af253bae7284b5704f2155ebe111d634e88fe005b9e19ce49eb8c4cea4f"},
+    {file = "ag2-0.1.13.tar.gz", hash = "sha256:ed6333338b45dcc3fa82ccec691d9229b29df0cfc019b0c53eb0c276c88e1f44"},
 ]
 
 [package.dependencies]

--- a/LLM/autogen/autogen_fastapi_ex/pyproject.toml
+++ b/LLM/autogen/autogen_fastapi_ex/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{include = "autogen_fastapi_ex"}]
 python = "^3.10"
 fastapi = "^0.109.2"
 uvicorn = {extras = ["standard"], version = "^0.23.2"}
-pyautogen = "^0.1.13"
+ag2 = "^0.1.13"
 
 
 [build-system]

--- a/LLM/autogen/notebooks/agentchat_RetrieveChat.ipynb
+++ b/LLM/autogen/notebooks/agentchat_RetrieveChat.ipynb
@@ -42,7 +42,7 @@
     "\n",
     "AutoGen requires `Python>=3.8`. To run this notebook example, please install the [retrievechat] option.\n",
     "```bash\n",
-    "pip install \"pyautogen[retrievechat]\" \"flaml[automl]\"\n",
+    "pip install \"ag2[retrievechat]\" \"flaml[automl]\"\n",
     "```"
    ]
   },
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install \"pyautogen[retrievechat]~=0.1.2\" \"flaml[automl]\""
+    "# %pip install \"ag2[retrievechat]~=0.1.2\" \"flaml[automl]\""
    ]
   },
   {

--- a/LLM/autogen/notebooks/agentchat_teachability.ipynb
+++ b/LLM/autogen/notebooks/agentchat_teachability.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "AutoGen requires `Python>=3.8`. To run this notebook example, please install the [teachable] option.\n",
     "```bash\n",
-    "pip install \"pyautogen[teachable]\"\n",
+    "pip install \"ag2[teachable]\"\n",
     "```"
    ]
   },
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "%%capture --no-stderr\n",
-    "# %pip install \"pyautogen[teachable]"
+    "# %pip install \"ag2[teachable]"
    ]
   },
   {

--- a/LLM/autogen/notebooks/agentchat_two_users.ipynb
+++ b/LLM/autogen/notebooks/agentchat_two_users.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "AutoGen requires `Python>=3.8`. To run this notebook example, please install:\n",
     "```bash\n",
-    "pip install pyautogen\n",
+    "pip install ag2\n",
     "```"
    ]
   },
@@ -44,7 +44,7 @@
    },
    "outputs": [],
    "source": [
-    "# %pip install pyautogen~=0.1.1"
+    "# %pip install ag2~=0.1.1"
    ]
   },
   {

--- a/LLM/autogen/notebooks/agentchat_web_info.ipynb
+++ b/LLM/autogen/notebooks/agentchat_web_info.ipynb
@@ -30,9 +30,9 @@
     "\n",
     "## Requirements\n",
     "\n",
-    "AutoGen requires `Python>=3.8`. To run this notebook example, please install pyautogen and docker:\n",
+    "AutoGen requires `Python>=3.8`. To run this notebook example, please install ag2 and docker:\n",
     "```bash\n",
-    "pip install pyautogen docker\n",
+    "pip install ag2 docker\n",
     "```"
    ]
   },
@@ -49,7 +49,7 @@
    },
    "outputs": [],
    "source": [
-    "# %pip install pyautogen~=0.1.0 docker"
+    "# %pip install ag2~=0.1.0 docker"
    ]
   },
   {

--- a/LLM/autogen/notebooks/oai_chatgpt_gpt4.ipynb
+++ b/LLM/autogen/notebooks/oai_chatgpt_gpt4.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "AutoGen requires `Python>=3.8`. To run this notebook example, please install with the [blendsearch] option:\n",
     "```bash\n",
-    "pip install \"pyautogen[blendsearch]\"\n",
+    "pip install \"ag2[blendsearch]\"\n",
     "```"
    ]
   },
@@ -51,7 +51,7 @@
    },
    "outputs": [],
    "source": [
-    "# %pip install \"pyautogen[blendsearch]\" datasets"
+    "# %pip install \"ag2[blendsearch]\" datasets"
    ]
   },
   {

--- a/LLM/autogen/notebooks/oai_completion.ipynb
+++ b/LLM/autogen/notebooks/oai_completion.ipynb
@@ -32,7 +32,7 @@
     "\n",
     "AutoGen requires `Python>=3.8`. To run this notebook example, please install with the [blendsearch] option:\n",
     "```bash\n",
-    "pip install pyautogen[blendsearch]\n",
+    "pip install ag2[blendsearch]\n",
     "```"
    ]
   },
@@ -49,7 +49,7 @@
    },
    "outputs": [],
    "source": [
-    "# %pip install \"pyautogen[blendsearch]~=0.1.0\" datasets"
+    "# %pip install \"ag2[blendsearch]~=0.1.0\" datasets"
    ]
   },
   {


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
